### PR TITLE
Fix package id

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cn.finalteam.rxgalleryfinal">
+    package="io.liaoyuan.reactnative.multipleimagepicker">
 </manifest>


### PR DESCRIPTION
Fixes #10 

我使用 Android Studio 3 编辑的时候，提示错误
```Error: A library uses the same package as this project: cn.finalteam.rxgalleryfinal```

将这个文件的 package 改了以后，就可以正常编译了，不太熟悉 Android，不知道这个地方是不是应该用实际的名字呢？